### PR TITLE
Revert "Removing pylint from library files and disabling black"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Unlicense
 
 repos:
+-   repo: https://github.com/python/black
+    rev: 20.8b1
+    hooks:
+    - id: black
 -   repo: https://github.com/fsfe/reuse-tool
     rev: v0.12.1
     hooks:
@@ -13,6 +17,13 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/pylint
+    rev: pylint-2.7.1
+    hooks:
+    -   id: pylint
+        name: pylint (library code)
+        types: [python]
+        exclude: "^(docs/|examples/|tests/|setup.py$)"
 -   repo: local
     hooks:
     -   id: pylint_examples

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ Introduction
     :target: https://github.com/adafruit/Adafruit_CircuitPython_asyncio/actions
     :alt: Build Status
 
+
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/psf/black
+    :alt: Code Style: Black
+
 Cooperative multitasking and asynchronous I/O
 
 The code in this library is largely based on the


### PR DESCRIPTION
Reverts adafruit/Adafruit_CircuitPython_asyncio#1. Per @kattni, we will disable pylint and black in the source files, instead of in the CI files.