### PR TITLE
Add Circuitpython style version and repo information

### DIFF
--- a/asyncio/__init__.py
+++ b/asyncio/__init__.py
@@ -13,7 +13,8 @@
 
 from .core import *
 
-__version__ = (3, 0, 0)
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/Adafruit/Adafruit_CircuitPython_asyncio.git"
 
 _attrs = {
     "wait_for": "funcs",


### PR DESCRIPTION
Changing `__version__` to the CP auto-generated one, and adding `__repo__` to the `__init__.py`
This should make it compatible with circup and fix https://github.com/adafruit/circup/issues/139