### PR TITLE
Warn when an `await` may be missing

### DIFF
--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -65,7 +65,7 @@ class SingletonGenerator:
 # Pause task execution for the given time (integer in milliseconds, uPy extension)
 # Use a SingletonGenerator to do it without allocating on the heap
 def sleep_ms(t, sgen=SingletonGenerator()):
-    assert sgen.state is None
+    assert sgen.state is None, "Check for a missing `await` in your code"
     sgen.state = ticks_add(ticks(), max(0, t))
     return sgen
 


### PR DESCRIPTION
If this `assert` fails, it is almost invariably due to a missing `await`:
https://github.com/dhalbert/Adafruit_CircuitPython_asyncio/blob/e8c2d389758d94629a12bfab92c6b11f2eb6cdbf/asyncio/core.py#L68

Add a message suggesting that the user should check for a missing `await`.

I have seen this multiple times, and someone else now saw it as well, for the same reason.
