### PR TITLE
Enable ThreadSafeFlag

### DIFF
--- a/asyncio/event.py
+++ b/asyncio/event.py
@@ -71,9 +71,9 @@ class Event:
 # that asyncio will poll until a flag is set.
 # Note: Unlike Event, this is self-clearing.
 try:
-    import uio
+    import io
 
-    class ThreadSafeFlag(uio.IOBase):
+    class ThreadSafeFlag(io.IOBase):
         def __init__(self):
             self._flag = 0
 


### PR DESCRIPTION
This didn't work since CircuitPython names the module `io`, not `uio`.

This extension to asyncio is not compatible with standard Python. However (like asyncio.sleep_ms), is a useful extension.

One thing about it is that the core can use ThreadSafeFlag to enable use like this:
```py
async def keyboard_task(pin):
    with keypad.Keys((pin,), value_when_pressed=False) as kb:
        while True:
            await kb.events.wait()
            print(kb.events.get())
```

Other changes are needed in the core before this works, and it still feels a bit of a hack. It's too bad you can't just write
```py
print(await kb.events.aget())
```
but I still didn't find a way for the `wait` to return a useful value. A Python-coded wrapper function such as
```py
async def aget(scanner):
    await scanner.events.wait()
    return scanner.events.get()
```
so now the only slightly awkward `await aget(kb)` is needed.