### PR TITLE
Added Ticks dependency to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+* `Ticks <https://github.com/adafruit/Adafruit_CircuitPython_Ticks>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading


### PR DESCRIPTION
Hi,

I was working on a board support for circuitpython and when testing this library as a frozen module it only works if [ticks ](https://github.com/adafruit/Adafruit_CircuitPython_Ticks) is also added.