### PR TITLE
Fix uses of 'await sleep(0)'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,6 @@ jobs:
       if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
       run: |
         pip install --upgrade build twine
-        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0+auto.0/1.2.3/" $file;
-        done;
+        find -type f -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) -exec sed -i -e "s/0.0.0+auto.0/1.2.3/" {} +
         python -m build
         twine check dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
-        done;
+        find -type f -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) -exec sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" {} +
         python -m build
         twine upload dist/*

--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -18,8 +18,11 @@ Core
 from adafruit_ticks import ticks_ms as ticks, ticks_diff, ticks_add
 import sys, select, traceback
 
-# Import TaskQueue and Task, unconditionally preferring Python code
-from .task import TaskQueue, Task
+# Import TaskQueue and Task, preferring built-in C code over Python code
+try:
+    from _asyncio import TaskQueue, Task
+except:
+    from .task import TaskQueue, Task
 
 
 ################################################################################

--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -18,11 +18,8 @@ Core
 from adafruit_ticks import ticks_ms as ticks, ticks_diff, ticks_add
 import sys, select, traceback
 
-# Import TaskQueue and Task, preferring built-in C code over Python code
-try:
-    from _asyncio import TaskQueue, Task
-except:
-    from .task import TaskQueue, Task
+# Import TaskQueue and Task, unconditionally preferring Python code
+from .task import TaskQueue, Task
 
 
 ################################################################################

--- a/asyncio/event.py
+++ b/asyncio/event.py
@@ -62,7 +62,8 @@ class Event:
             self.waiting.push_head(core.cur_task)
             # Set calling task's data to the event's queue so it can be removed if needed
             core.cur_task.data = self.waiting
-            yield
+            core._never.state = False
+            await core._never
         return True
 
 

--- a/asyncio/event.py
+++ b/asyncio/event.py
@@ -62,7 +62,7 @@ class Event:
             self.waiting.push_head(core.cur_task)
             # Set calling task's data to the event's queue so it can be removed if needed
             core.cur_task.data = self.waiting
-            await core.sleep(0)
+            yield
         return True
 
 

--- a/asyncio/funcs.py
+++ b/asyncio/funcs.py
@@ -106,7 +106,7 @@ async def gather(*aws, return_exceptions=False):
             #        # cancel all waiting tasks
             #        raise er
             ts[i] = await ts[i]
-        except Exception as er:
+        except (core.CancelledError, Exception) as er:
             if return_exceptions:
                 ts[i] = er
             else:

--- a/asyncio/lock.py
+++ b/asyncio/lock.py
@@ -69,7 +69,8 @@ class Lock:
             # Set calling task's data to the lock's queue so it can be removed if needed
             core.cur_task.data = self.waiting
             try:
-                yield
+                core._never.state = False
+                await core._never
             except core.CancelledError as er:
                 if self.state == core.cur_task:
                     # Cancelled while pending on resume, schedule next waiting Task

--- a/asyncio/lock.py
+++ b/asyncio/lock.py
@@ -69,7 +69,7 @@ class Lock:
             # Set calling task's data to the lock's queue so it can be removed if needed
             core.cur_task.data = self.waiting
             try:
-                await core.sleep(0)
+                yield
             except core.CancelledError as er:
                 if self.state == core.cur_task:
                     # Cancelled while pending on resume, schedule next waiting Task


### PR DESCRIPTION
This set of changes, together with some other changes in the core and in adafruit_circuitpython_ticks, allow all the asyncio-related core tests to pass at build time (that is, with the ports/unix build).

Probably a good place to discuss this is 
 * https://github.com/adafruit/circuitpython/pull/7059/

Micropython can use a non-standard construct of `yield` in an `async def` to cause the async function to be suspended indefinitely, until some other task causes it to be scheduled again. `await sleep(0)` is equivalent, so an internal "_Never" class is introduced which can do this in a way that is syntactically valid in standard Python as well.

~~When using the core implementation of Task & TaskGroup, there are Problems, so this PR disables that. Doing so might also fix the following issues in the core repo, but I didn't specifically test them:~~

This Closes https://github.com/adafruit/circuitpython/issues/6954 but https://github.com/adafruit/circuitpython/issues/6706 is not fixed (a different core change will fix that one)