### PR TITLE
Rework how the never singleton is invoked

### DIFF
--- a/asyncio/event.py
+++ b/asyncio/event.py
@@ -62,8 +62,7 @@ class Event:
             self.waiting.push_head(core.cur_task)
             # Set calling task's data to the event's queue so it can be removed if needed
             core.cur_task.data = self.waiting
-            core._never.state = False
-            await core._never
+            await core._never()
         return True
 
 

--- a/asyncio/lock.py
+++ b/asyncio/lock.py
@@ -69,8 +69,7 @@ class Lock:
             # Set calling task's data to the lock's queue so it can be removed if needed
             core.cur_task.data = self.waiting
             try:
-                core._never.state = False
-                await core._never
+                await core._never()
             except core.CancelledError as er:
                 if self.state == core.cur_task:
                     # Cancelled while pending on resume, schedule next waiting Task


### PR DESCRIPTION
Now you can just `await _never()` rather than a two-line sequence.

This is the refactor I mentioned in https://github.com/adafruit/Adafruit_CircuitPython_asyncio/pull/33#issuecomment-1299489739