### PR TITLE
Add the package-prefix parameter to the github release action

### DIFF
--- a/.github/workflows/release_gh.yml
+++ b/.github/workflows/release_gh.yml
@@ -15,5 +15,6 @@ jobs:
     - name: Run GitHub Release CI workflow
       uses: adafruit/workflows-circuitpython-libs/release-gh@main
       with:
+        package-prefix: "asyncio"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         upload-url: ${{ github.event.release.upload_url }}


### PR DESCRIPTION
With the recent release, the zip only contains the examples folder.
This is due to the release action not using a `--package_folder_prefix` unless specified in the inputs of the action.

For comparison, the Adafruit bundle uses `--package_folder_prefix "adafruit_, asyncio"`
