### PR TITLE
chore: move CancelledError and InvalidStateError to tasks

### DIFF
--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -26,7 +26,7 @@ except ImportError:
 
 # Depending on the release of CircuitPython these errors may or may not
 # exist in the C implementation of `_asyncio`.  However, when they
-# do exist, must be preferred over the Python code.
+# do exist, they must be preferred over the Python code.
 try:
     from _asyncio import CancelledError, InvalidStateError
 except (ImportError, AttributeError):

--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -24,15 +24,15 @@ try:
 except:
     from .task import TaskQueue, Task
 
+# Depending on the version of CircuitPython, these errors may exist in the build-in C code
+# even if _asyncio exists
+try:
+    from _asyncio import CancelledError, InvalidStateError
+except:
+    from .task import CancelledError, InvalidStateError
 
 ################################################################################
 # Exceptions
-
-
-class CancelledError(BaseException):
-    """Injected into a task when calling `Task.cancel()`"""
-
-    pass
 
 
 class TimeoutError(Exception):

--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -24,16 +24,24 @@ try:
 except ImportError:
     from .task import TaskQueue, Task
 
+################################################################################
+# Exceptions
+
+
 # Depending on the release of CircuitPython these errors may or may not
 # exist in the C implementation of `_asyncio`.  However, when they
 # do exist, they must be preferred over the Python code.
 try:
     from _asyncio import CancelledError, InvalidStateError
 except (ImportError, AttributeError):
-    from .task import CancelledError, InvalidStateError
+    class CancelledError(BaseException):
+        """Injected into a task when calling `Task.cancel()`"""
+        pass
 
-################################################################################
-# Exceptions
+
+    class InvalidStateError(Exception):
+        """Can be raised in situations like setting a result value for a task object that already has a result value set."""
+        pass
 
 
 class TimeoutError(Exception):

--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -21,14 +21,15 @@ import sys, select, traceback
 # Import TaskQueue and Task, preferring built-in C code over Python code
 try:
     from _asyncio import TaskQueue, Task
-except:
+except ImportError:
     from .task import TaskQueue, Task
 
-# Depending on the version of CircuitPython, these errors may exist in the build-in C code
-# even if _asyncio exists
+# Depending on the release of CircuitPython these errors may or may not
+# exist in the C implementation of `_asyncio`.  However, when they
+# do exist, must be preferred over the Python code.
 try:
     from _asyncio import CancelledError, InvalidStateError
-except:
+except (ImportError, AttributeError):
     from .task import CancelledError, InvalidStateError
 
 ################################################################################

--- a/asyncio/task.py
+++ b/asyncio/task.py
@@ -21,6 +21,18 @@ Tasks
 from . import core
 
 
+class CancelledError(BaseException):
+    """Injected into a task when calling `Task.cancel()`"""
+
+    pass
+
+
+class InvalidStateError(Exception):
+    """Can be raised in situations like setting a result value for a task object that already has a result value set."""
+
+    pass
+
+
 # pairing-heap meld of 2 heaps; O(1)
 def ph_meld(h1, h2):
     if h1 is None:

--- a/asyncio/task.py
+++ b/asyncio/task.py
@@ -21,18 +21,6 @@ Tasks
 from . import core
 
 
-class CancelledError(BaseException):
-    """Injected into a task when calling `Task.cancel()`"""
-
-    pass
-
-
-class InvalidStateError(Exception):
-    """Can be raised in situations like setting a result value for a task object that already has a result value set."""
-
-    pass
-
-
 # pairing-heap meld of 2 heaps; O(1)
 def ph_meld(h1, h2):
     if h1 is None:


### PR DESCRIPTION
this moves `CancelledError` and creates `InvalidStateError` within tasks to support #54 & https://github.com/adafruit/circuitpython/pull/8576 -- and done in a way so that if we were to include these in `_asyncio` that we use the C exceptions better

This is being done in a separate PR so that the CircuitPython tests that run will get the expected `CancelledError` and operate as expected.

Open to other suggestions, though!