### PR TITLE
Remove non-working Stream __aenter__/__aexit__ methods.

### DIFF
--- a/asyncio/stream.py
+++ b/asyncio/stream.py
@@ -36,12 +36,6 @@ class Stream:
 
         return self.e[v]
 
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        await self.close()
-
     def close(self):
         pass
 


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_CircuitPython_asyncio/issues/63