### PR TITLE
remove push_head, push_sorted, pop_head

### DIFF
--- a/asyncio/core.py
+++ b/asyncio/core.py
@@ -81,8 +81,7 @@ class SingletonGenerator:
 
     def __next__(self):
         if self.state is not None:
-             # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-            _task_queue.push_sorted(cur_task, self.state)
+            _task_queue.push(cur_task, self.state)
             self.state = None
             return None
         else:
@@ -209,13 +208,11 @@ class IOQueue:
             # print('poll', s, sm, ev)
             if ev & ~select.POLLOUT and sm[0] is not None:
                 # POLLIN or error
-                 # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-                _task_queue.push_head(sm[0])
+                _task_queue.push(sm[0])
                 sm[0] = None
             if ev & ~select.POLLIN and sm[1] is not None:
                 # POLLOUT or error
-                 # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-                _task_queue.push_head(sm[1])
+                _task_queue.push(sm[1])
                 sm[1] = None
             if sm[0] is None and sm[1] is None:
                 self._dequeue(s)
@@ -245,8 +242,7 @@ def create_task(coro):
     if not hasattr(coro, "send"):
         raise TypeError("coroutine expected")
     t = Task(coro, globals())
-     # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-    _task_queue.push_head(t)
+    _task_queue.push(t)
     return t
 
 
@@ -275,8 +271,7 @@ def run_until_complete(main_task=None):
             _io_queue.wait_io_event(dt)
 
         # Get next task to run and continue it
-        # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .pop()
-        t = _task_queue.pop_head()
+        t = _task_queue.pop()
         cur_task = t
         try:
             # Continue running the coroutine, it's responsible for rescheduling itself
@@ -313,8 +308,7 @@ def run_until_complete(main_task=None):
                 else:
                     # Schedule any other tasks waiting on the completion of this task.
                     while t.state.peek():
-                         # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push() and .pop()
-                        _task_queue.push_head(t.state.pop_head())
+                        _task_queue.push(t.state.pop())
                         waiting = True
                     # "False" indicates that the task is complete and has been await'ed on.
                     t.state = False
@@ -322,8 +316,7 @@ def run_until_complete(main_task=None):
                     # An exception ended this detached task, so queue it for later
                     # execution to handle the uncaught exception if no other task retrieves
                     # the exception in the meantime (this is handled by Task.throw).
-                     # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-                    _task_queue.push_head(t)
+                    _task_queue.push(t)
                 # Save return value of coro to pass up to caller.
                 t.data = er
             elif t.state is None:
@@ -397,8 +390,7 @@ class Loop:
 
         global _stop_task
         if _stop_task is not None:
-             # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-            _task_queue.push_head(_stop_task)
+            _task_queue.push(_stop_task)
             # If stop() is called again, do nothing
             _stop_task = None
 

--- a/asyncio/event.py
+++ b/asyncio/event.py
@@ -42,8 +42,7 @@ class Event:
         # Note: This must not be called from anything except the thread running
         # the asyncio loop (i.e. neither hard or soft IRQ, or a different thread).
         while self.waiting.peek():
-             # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push() and .pop()
-            core._task_queue.push_head(self.waiting.pop_head())
+            core._task_queue.push(self.waiting.pop())
         self.state = True
 
     def clear(self):
@@ -61,8 +60,7 @@ class Event:
 
         if not self.state:
             # Event not set, put the calling task on the event's waiting queue
-             # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-            self.waiting.push_head(core.cur_task)
+            self.waiting.push(core.cur_task)
             # Set calling task's data to the event's queue so it can be removed if needed
             core.cur_task.data = self.waiting
              # CIRCUITPY-CHANGE: use await; never reschedule

--- a/asyncio/funcs.py
+++ b/asyncio/funcs.py
@@ -122,8 +122,7 @@ async def gather(*aws, return_exceptions=False):
                 # Still some sub-tasks running.
                 return
         # Gather waiting is done, schedule the main gather task.
-        # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-        core._task_queue.push_head(gather_task)
+        core._task_queue.push(gather_task)
 
     # Prepare the sub-tasks for the gather.
     # The `state` variable counts the number of tasks to wait for, and can be negative

--- a/asyncio/lock.py
+++ b/asyncio/lock.py
@@ -55,9 +55,8 @@ class Lock:
             raise RuntimeError("Lock not acquired")
         if self.waiting.peek():
             # Task(s) waiting on lock, schedule next Task
-             # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .pop() and .push()
-            self.state = self.waiting.pop_head()
-            core._task_queue.push_head(self.state)
+            self.state = self.waiting.pop()
+            core._task_queue.push(self.state)
         else:
             # No Task waiting so unlock
             self.state = 0
@@ -71,8 +70,7 @@ class Lock:
 
         if self.state != 0:
             # Lock unavailable, put the calling Task on the waiting queue
-             # CIRCUITPY-CHANGE: when 8.x support is discontinued, change to .push()
-            self.waiting.push_head(core.cur_task)
+            self.waiting.push(core.cur_task)
             # Set calling task's data to the lock's queue so it can be removed if needed
             core.cur_task.data = self.waiting
             try:

--- a/asyncio/task.py
+++ b/asyncio/task.py
@@ -128,10 +128,6 @@ class TaskQueue:
     def remove(self, v):
         self.heap = ph_delete(self.heap, v)
 
-    # CIRCUITPY-CHANGE: Compatibility aliases, remove after 8.x is no longer supported
-    push_head = push
-    push_sorted = push
-    pop_head = pop
 
 # Task class representing a coroutine, can be waited on and cancelled.
 class Task:


### PR DESCRIPTION
- Related to https://github.com/adafruit/circuitpython/issues/9595

Replace deprecated task queue operations, now that CircuitPython 8.x builds are no longer included in new library bundles
- `push_head` -> `push`
- `push_sorted` -> `push`
- `pop_head` -> `pop`